### PR TITLE
Cleaned up &self syntax, added remove-atom, and fixed a >= operator bug.

### DIFF
--- a/src/backend/eval/mod.rs
+++ b/src/backend/eval/mod.rs
@@ -1748,6 +1748,43 @@ mod tests {
     }
 
     #[test]
+    fn test_greater_than_or_equal_operator() {
+        // Regression test for >= operator
+        // Tests all cases: greater, equal, and less
+        let env = Environment::new();
+
+        // Test: 5 >= 3 should be true (greater case)
+        let value = MettaValue::SExpr(vec![
+            MettaValue::Atom(">=".to_string()),
+            MettaValue::Long(5),
+            MettaValue::Long(3),
+        ]);
+        let (results, _) = eval(value, env.clone());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], MettaValue::Bool(true));
+
+        // Test: 3 >= 3 should be true (equal case)
+        let value = MettaValue::SExpr(vec![
+            MettaValue::Atom(">=".to_string()),
+            MettaValue::Long(3),
+            MettaValue::Long(3),
+        ]);
+        let (results, _) = eval(value, env.clone());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], MettaValue::Bool(true));
+
+        // Test: 2 >= 5 should be false (less case)
+        let value = MettaValue::SExpr(vec![
+            MettaValue::Atom(">=".to_string()),
+            MettaValue::Long(2),
+            MettaValue::Long(5),
+        ]);
+        let (results, _) = eval(value, env);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], MettaValue::Bool(false));
+    }
+
+    #[test]
     fn test_equality_literals() {
         // From c1_grounded_basic.metta: (== 4 (+ 2 2))
         let env = Environment::new();

--- a/src/backend/eval/space.rs
+++ b/src/backend/eval/space.rs
@@ -75,7 +75,7 @@ pub(super) fn eval_match(items: Vec<MettaValue>, env: Environment) -> EvalResult
     // Parse space reference (e.g., &self)
     match space_ref {
         MettaValue::Atom(s) if s.starts_with('&') => {
-            let space_name = &s[1..];  // Extract "self" from "&self"
+            let space_name = &s[1..]; // Extract "self" from "&self"
 
             if space_name == "self" {
                 // Use optimized match_space method that works directly with MORK
@@ -153,7 +153,10 @@ pub(super) fn eval_add_atom(items: Vec<MettaValue>, env: Environment) -> EvalRes
                 (vec![], new_env)
             } else {
                 let err = MettaValue::Error(
-                    format!("add-atom only supports '&self' as space reference, got: {:?}", space_ref),
+                    format!(
+                        "add-atom only supports '&self' as space reference, got: {:?}",
+                        space_ref
+                    ),
                     Arc::new(MettaValue::SExpr(args.to_vec())),
                 );
                 (vec![err], env)
@@ -208,13 +211,16 @@ pub(super) fn eval_remove_atom(items: Vec<MettaValue>, env: Environment) -> Eval
 
                 // Remove atom from environment's MORK space
                 // Note: remove_from_space returns bool indicating if atom was found
-                let _removed = new_env.remove_from_space(atom);
+                new_env.remove_from_space(atom);
 
                 // Return empty list (idempotent - success even if not found)
                 (vec![], new_env)
             } else {
                 let err = MettaValue::Error(
-                    format!("remove-atom only supports '&self' as space reference, got: {:?}", space_ref),
+                    format!(
+                        "remove-atom only supports '&self' as space reference, got: {:?}",
+                        space_ref
+                    ),
                     Arc::new(MettaValue::SExpr(args.to_vec())),
                 );
                 (vec![err], env)
@@ -636,7 +642,9 @@ mod tests {
         assert_eq!(results.len(), 1);
         match &results[0] {
             MettaValue::Error(msg, _) => {
-                assert!(msg.contains("match requires space reference (e.g., &self) as first argument"));
+                assert!(
+                    msg.contains("match requires space reference (e.g., &self) as first argument")
+                );
             }
             _ => panic!("Expected error for wrong space reference"),
         }

--- a/src/tree_sitter_parser.rs
+++ b/src/tree_sitter_parser.rs
@@ -532,10 +532,7 @@ mod tests {
 
         // & prefix creates space reference token (like $var for variables)
         let result = strip_spans_vec(&parser.parse("&y").unwrap());
-        assert_eq!(
-            result,
-            vec![SExpr::Atom("&y".to_string(), None)]
-        );
+        assert_eq!(result, vec![SExpr::Atom("&y".to_string(), None)]);
 
         // Wildcard
         let result = strip_spans_vec(&parser.parse("_").unwrap());


### PR DESCRIPTION
The syntax for spaces in HE MeTTa (which has some WIP [specs](https://github.com/vsbogd/hyperon-experimental/blob/metta-doc/docs/metta.md) by Vitaly) and PeTTa is &self (&kb, etc).  In MeTTa-Compiler, it was bing treated as (match & self $pattern $result) instead of (match &self $pattern $result).

This PR fixes this, as well as adding add-atom and remove-atom.

The code may be imperfect (implemented by Claude Code), but I hope it at least inspires :).