### PR TITLE
feat(types): add MettaValue::Unit variant

### DIFF
--- a/src/backend/eval/mod.rs
+++ b/src/backend/eval/mod.rs
@@ -145,6 +145,7 @@ pub(crate) fn friendly_value_repr(value: &MettaValue) -> String {
             let inner: Vec<String> = goals.iter().map(friendly_value_repr).collect();
             format!("(, {})", inner.join(" "))
         }
+        MettaValue::Unit => "()".to_string(),
     }
 }
 
@@ -455,7 +456,8 @@ fn eval_step(value: MettaValue, env: Environment, depth: usize) -> EvalStep {
         | MettaValue::Float(_)
         | MettaValue::String(_)
         | MettaValue::Nil
-        | MettaValue::Type(_) => EvalStep::Done((vec![value], env)),
+        | MettaValue::Type(_)
+        | MettaValue::Unit => EvalStep::Done((vec![value], env)),
 
         // S-expressions need special handling
         MettaValue::SExpr(items) => eval_sexpr_step(items, env, depth),
@@ -949,7 +951,8 @@ fn pattern_specificity(pattern: &MettaValue) -> usize {
         | MettaValue::Long(_)
         | MettaValue::Float(_)
         | MettaValue::String(_)
-        | MettaValue::Nil => {
+        | MettaValue::Nil
+        | MettaValue::Unit => {
             0 // Literals are most specific (including standalone "&")
         }
         MettaValue::SExpr(items) => {

--- a/src/backend/eval/types.rs
+++ b/src/backend/eval/types.rs
@@ -193,6 +193,9 @@ fn infer_type(expr: &MettaValue, env: &Environment) -> MettaValue {
                 infer_type(goals.last().unwrap(), env)
             }
         }
+
+        // Unit has Unit type
+        MettaValue::Unit => MettaValue::Atom("Unit".to_string()),
     }
 }
 

--- a/src/backend/models/metta_value.rs
+++ b/src/backend/models/metta_value.rs
@@ -28,6 +28,9 @@ pub enum MettaValue {
     /// Represents (,), (, expr), or (, expr1 expr2 ...)
     /// Goals are evaluated left-to-right with variable binding threading
     Conjunction(Vec<MettaValue>),
+    /// Unit value - represents a successful operation with no meaningful return value
+    /// Similar to () in Rust or void in other languages
+    Unit,
 }
 
 impl MettaValue {
@@ -57,6 +60,7 @@ impl MettaValue {
                 | MettaValue::Float(_)
                 | MettaValue::String(_)
                 | MettaValue::Nil
+                | MettaValue::Unit
         )
     }
 
@@ -74,6 +78,7 @@ impl MettaValue {
             MettaValue::Error(_, _) => "Error",
             MettaValue::Type(_) => "Type",
             MettaValue::Conjunction(_) => "Conjunction",
+            MettaValue::Unit => "Unit",
         }
     }
 
@@ -149,6 +154,9 @@ impl MettaValue {
                     .zip(b_goals.iter())
                     .all(|(a, b)| a.structurally_equivalent(b))
             }
+
+            // Unit matches unit
+            (MettaValue::Unit, MettaValue::Unit) => true,
 
             _ => false,
         }
@@ -235,6 +243,7 @@ impl MettaValue {
                     .join(" ");
                 format!("(, {})", inner)
             }
+            MettaValue::Unit => "()".to_string(),
         }
     }
 
@@ -271,6 +280,7 @@ impl MettaValue {
                     goals_json.join(",")
                 )
             }
+            MettaValue::Unit => r#"{"type":"unit"}"#.to_string(),
         }
     }
 }
@@ -331,6 +341,9 @@ impl std::hash::Hash for MettaValue {
             MettaValue::Conjunction(goals) => {
                 10u8.hash(state);
                 goals.hash(state);
+            }
+            MettaValue::Unit => {
+                11u8.hash(state);
             }
         }
     }

--- a/src/backend/mork_convert.rs
+++ b/src/backend/mork_convert.rs
@@ -182,6 +182,12 @@ fn write_metta_value(
                 write_metta_value(goal, space, ctx, ez)?;
             }
         }
+
+        MettaValue::Unit => {
+            // Unit is represented as empty list (similar to Nil)
+            ez.write_arity(0);
+            ez.loc += 1;
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,7 @@ fn format_result(value: &MettaValue) -> String {
             let formatted: Vec<String> = goals.iter().map(format_result).collect();
             format!("(, {})", formatted.join(" "))
         }
+        MettaValue::Unit => "()".to_string(),
     }
 }
 

--- a/src/pathmap_par_integration.rs
+++ b/src/pathmap_par_integration.rs
@@ -105,6 +105,10 @@ pub fn metta_value_to_par(value: &MettaValue) -> Par {
                 })),
             }])
         }
+        MettaValue::Unit => {
+            // Represent Unit as empty Par (similar to Nil)
+            Par::default()
+        }
     };
 
     trace!(target: "mettatron::rholang_integration::metta_value_to_par", ?par, "Par");

--- a/tests/common/output_parser.rs
+++ b/tests/common/output_parser.rs
@@ -43,6 +43,7 @@ impl MettaValueTestExt for MettaValue {
                 let inner: Vec<String> = goals.iter().map(|g| g.to_display_string()).collect();
                 format!("(, {})", inner.join(" "))
             }
+            MettaValue::Unit => "()".to_string(),
         }
     }
 
@@ -61,6 +62,7 @@ impl MettaValueTestExt for MettaValue {
             MettaValue::Nil => s == "()" || s == "Nil",
             MettaValue::Type(_) => self.to_display_string() == s,
             MettaValue::Conjunction(_) => self.to_display_string() == s,
+            MettaValue::Unit => s == "()" || s == "Unit",
         }
     }
 }


### PR DESCRIPTION
## Summary

Add MettaValue type extensions for bytecode compilation:
- Unit variant for void/nil representation
- Type system extensions for bytecode integration

## Part of Stacked PR Series

This is PR #03 in a 28-PR stacked series implementing the bytecode VM and JIT compiler.
**Base**: `pr02/bytecode-compiler`
**Next**: `pr04/jit-types`

---
*This PR series implements tiered compilation: tree-walker → bytecode VM → JIT native code*