### PR TITLE
feat(models): add MettaValue helper methods

### DIFF
--- a/src/backend/models/metta_value.rs
+++ b/src/backend/models/metta_value.rs
@@ -1198,12 +1198,15 @@ mod tests {
     #[test]
     fn test_type_name_number() {
         assert_eq!(MettaValue::Long(42).type_name(), "Number");
-        assert_eq!(MettaValue::Float(3.14).type_name(), "Number");
+        assert_eq!(MettaValue::Float(1.5).type_name(), "Number");
     }
 
     #[test]
     fn test_type_name_string() {
-        assert_eq!(MettaValue::String("hello".to_string()).type_name(), "String");
+        assert_eq!(
+            MettaValue::String("hello".to_string()).type_name(),
+            "String"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add MettaValue helper methods for bytecode operations:
- Convenient accessors for value types
- Conversion utilities for bytecode interop
- Type checking helper methods

## Part of Stacked PR Series

This is PR #06 in a 28-PR stacked series implementing the bytecode VM and JIT compiler.
**Base**: `pr05/bytecode-chunk`
**Next**: `pr07/models-memo-bindings`

---
*This PR series implements tiered compilation: tree-walker → bytecode VM → JIT native code*