### PR TITLE
feat(models): add SpaceHandle for first-class queryable spaces

### DIFF
--- a/src/backend/bytecode/cache.rs
+++ b/src/backend/bytecode/cache.rs
@@ -89,7 +89,9 @@ pub fn hash_metta_value(expr: &MettaValue) -> u64 {
     match expr {
         MettaValue::Long(n) => {
             // FxHash-style mixing with type-specific seed
-            let x = (*n as u64).wrapping_add(LONG_SEED).wrapping_mul(GOLDEN_RATIO);
+            let x = (*n as u64)
+                .wrapping_add(LONG_SEED)
+                .wrapping_mul(GOLDEN_RATIO);
             x ^ (x >> 32)
         }
         MettaValue::Bool(b) => {
@@ -120,14 +122,18 @@ pub fn hash_metta_value(expr: &MettaValue) -> u64 {
 #[inline]
 pub fn get_cached_can_compile(hash: u64) -> Option<bool> {
     // Use peek() + read lock for faster lookups (doesn't update LRU order)
-    let cache = CAN_COMPILE_CACHE.read().expect("can_compile cache lock poisoned");
+    let cache = CAN_COMPILE_CACHE
+        .read()
+        .expect("can_compile cache lock poisoned");
     cache.peek(&hash).copied()
 }
 
 /// Store can_compile result in cache
 #[inline]
 pub fn cache_can_compile(hash: u64, compilable: bool) {
-    let mut cache = CAN_COMPILE_CACHE.write().expect("can_compile cache lock poisoned");
+    let mut cache = CAN_COMPILE_CACHE
+        .write()
+        .expect("can_compile cache lock poisoned");
     cache.put(hash, compilable);
 }
 
@@ -142,16 +148,15 @@ pub fn get_cached_bytecode(hash: u64) -> Option<Arc<BytecodeChunk>> {
 /// Store compiled bytecode chunk in cache
 #[inline]
 pub fn cache_bytecode(hash: u64, chunk: Arc<BytecodeChunk>) {
-    let mut cache = BYTECODE_CACHE.write().expect("bytecode cache lock poisoned");
+    let mut cache = BYTECODE_CACHE
+        .write()
+        .expect("bytecode cache lock poisoned");
     cache.put(hash, chunk);
 }
 
 /// Get current cache statistics
 pub fn get_stats() -> BytecodeCacheStats {
-    CACHE_STATS
-        .read()
-        .expect("stats lock poisoned")
-        .clone()
+    CACHE_STATS.read().expect("stats lock poisoned").clone()
 }
 
 /// Clear all caches (mainly for testing)
@@ -169,14 +174,8 @@ pub fn clear_caches() {
 
 /// Get current cache sizes (for diagnostics)
 pub fn cache_sizes() -> (usize, usize) {
-    let can_compile_size = CAN_COMPILE_CACHE
-        .read()
-        .map(|c| c.len())
-        .unwrap_or(0);
-    let bytecode_size = BYTECODE_CACHE
-        .read()
-        .map(|c| c.len())
-        .unwrap_or(0);
+    let can_compile_size = CAN_COMPILE_CACHE.read().map(|c| c.len()).unwrap_or(0);
+    let bytecode_size = BYTECODE_CACHE.read().map(|c| c.len()).unwrap_or(0);
     (can_compile_size, bytecode_size)
 }
 
@@ -295,7 +294,7 @@ mod tests {
         let h_float = hash_metta_value(&MettaValue::Float(0.0));
 
         // All should be distinct
-        let hashes = vec![h_long, h_false, h_nil, h_float];
+        let hashes = [h_long, h_false, h_nil, h_float];
         for i in 0..hashes.len() {
             for j in i + 1..hashes.len() {
                 assert_ne!(

--- a/src/backend/bytecode/mork_bridge.rs
+++ b/src/backend/bytecode/mork_bridge.rs
@@ -26,8 +26,8 @@ use std::sync::{Arc, RwLock};
 use tracing::warn;
 
 use crate::backend::environment::Environment;
-use crate::backend::models::{Bindings, MettaValue};
 use crate::backend::eval::pattern_match;
+use crate::backend::models::{Bindings, MettaValue};
 
 use super::chunk::BytecodeChunk;
 use super::compiler::{compile, CompileError};
@@ -193,7 +193,12 @@ impl MorkBridge {
         for rule in matching_rules {
             if let Some(bindings) = pattern_match(&rule.lhs, expr) {
                 let specificity = pattern_specificity(&rule.lhs);
-                matches.push((Arc::new(rule.lhs.clone()), Arc::new(rule.rhs.clone()), bindings, specificity));
+                matches.push((
+                    Arc::new(rule.lhs.clone()),
+                    Arc::new(rule.rhs.clone()),
+                    bindings,
+                    specificity,
+                ));
             }
         }
 
@@ -257,12 +262,10 @@ impl MorkBridge {
 /// Extract head symbol from an expression
 fn get_head_symbol(expr: &MettaValue) -> Option<&str> {
     match expr {
-        MettaValue::SExpr(items) if !items.is_empty() => {
-            match &items[0] {
-                MettaValue::Atom(name) => Some(name.as_str()),
-                _ => None,
-            }
-        }
+        MettaValue::SExpr(items) if !items.is_empty() => match &items[0] {
+            MettaValue::Atom(name) => Some(name.as_str()),
+            _ => None,
+        },
         MettaValue::Atom(name) => Some(name.as_str()),
         _ => None,
     }
@@ -277,11 +280,12 @@ fn pattern_specificity(pattern: &MettaValue) -> usize {
     match pattern {
         MettaValue::Atom(name) if name == "_" => 1000, // Wildcard - least specific
         MettaValue::Atom(name) if name.starts_with('$') => 100, // Variable
-        MettaValue::Atom(_) => 0, // Concrete symbol
-        MettaValue::SExpr(items) => {
-            items.iter().map(pattern_specificity).sum()
-        }
-        MettaValue::Long(_) | MettaValue::Float(_) | MettaValue::Bool(_) | MettaValue::String(_) => 0,
+        MettaValue::Atom(_) => 0,                      // Concrete symbol
+        MettaValue::SExpr(items) => items.iter().map(pattern_specificity).sum(),
+        MettaValue::Long(_)
+        | MettaValue::Float(_)
+        | MettaValue::Bool(_)
+        | MettaValue::String(_) => 0,
         _ => 50, // Other types
     }
 }
@@ -343,9 +347,10 @@ mod tests {
 
         // Check bindings - pattern_match keeps the $ prefix in variable names
         let compiled = &rules[0];
-        assert!(compiled.bindings.iter().any(|(name, val)| {
-            name == "$x" && *val == MettaValue::Long(5)
-        }));
+        assert!(compiled
+            .bindings
+            .iter()
+            .any(|(name, val)| { name == "$x" && *val == MettaValue::Long(5) }));
     }
 
     #[test]
@@ -397,15 +402,21 @@ mod tests {
         assert_eq!(pattern_specificity(&MettaValue::Atom("foo".to_string())), 0);
 
         // Variable - less specific
-        assert_eq!(pattern_specificity(&MettaValue::Atom("$x".to_string())), 100);
+        assert_eq!(
+            pattern_specificity(&MettaValue::Atom("$x".to_string())),
+            100
+        );
 
         // Wildcard - least specific
-        assert_eq!(pattern_specificity(&MettaValue::Atom("_".to_string())), 1000);
+        assert_eq!(
+            pattern_specificity(&MettaValue::Atom("_".to_string())),
+            1000
+        );
 
         // S-expression adds up
         let sexpr = MettaValue::SExpr(vec![
-            MettaValue::Atom("foo".to_string()),  // 0
-            MettaValue::Atom("$x".to_string()),   // 100
+            MettaValue::Atom("foo".to_string()), // 0
+            MettaValue::Atom("$x".to_string()),  // 100
         ]);
         assert_eq!(pattern_specificity(&sexpr), 100);
     }

--- a/src/backend/models/space_handle.rs
+++ b/src/backend/models/space_handle.rs
@@ -195,7 +195,7 @@ impl SpaceHandle {
                     }
                 }
             }
-            SpaceBacking::Module { mod_id, space } => {
+            SpaceBacking::Module { mod_id: _, space } => {
                 // Module spaces: for now, fork creates a snapshot (not live)
                 // This gives each branch its own isolated copy
                 let atoms = space.read().unwrap().get_all_atoms();
@@ -487,10 +487,9 @@ impl SpaceHandle {
                         _ => false,
                     }
             }
-            (
-                SpaceBacking::Module { mod_id: a, .. },
-                SpaceBacking::Module { mod_id: b, .. },
-            ) => a == b,
+            (SpaceBacking::Module { mod_id: a, .. }, SpaceBacking::Module { mod_id: b, .. }) => {
+                a == b
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
## Summary

Add first-class space handling:
- SpaceHandle type for queryable spaces
- Space creation and management APIs
- Space-based pattern matching integration

## Part of Stacked PR Series

This is PR #12 in a 28-PR stacked series implementing the bytecode VM and JIT compiler.
**Base**: `pr11/modules-system`
**Next**: `pr13/env-dependencies`

---
*This PR series implements tiered compilation: tree-walker → bytecode VM → JIT native code*